### PR TITLE
Fix for Rake Warning

### DIFF
--- a/features/testgen_project.feature
+++ b/features/testgen_project.feature
@@ -14,6 +14,7 @@ Feature: Generating a project with TestGen
     Then a file named "sample/Gemfile" should exist
     And the file "sample/Gemfile" should contain "gem 'cucumber'"
     And the file "sample/Gemfile" should contain "gem 'rspec'"
+    And the file "sample/Gemfile" should contain "gem 'rake'"
     And the file "sample/Gemfile" should contain "source 'https://rubygems.org'"
 
     

--- a/lib/testgen/generators/project/Gemfile.tt
+++ b/lib/testgen/generators/project/Gemfile.tt
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 gem 'cucumber'
 gem 'rspec'
+gem 'rake'
 <% unless pageobject_driver.downcase == 'none' -%>
 gem 'page-object'
 <% end -%>


### PR DESCRIPTION
RubyMine detects that a Rakefile is generated when generating a new project, and complains about Rake not being in the Gemfile when performing a bundle install, this is a small fix for it.
