### PR TITLE
Updates readme.md as per removed driver option

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -33,7 +33,7 @@ If you are testing a native windows application, <em>testgen</em> can setup the 
 
 There is another option available with will create the page or screen directory in a base directoy named lib.  It will also setup the project so these files get loaded the same way they would if the directory was in the support directory.  Here's an example of creating a project for web testing using the lib option:
 
-    testgen project <project_name> --pageobject-driver=watir --with-lib
+    testgen project <project_name> --with-lib
 
 
 


### PR DESCRIPTION
This commit removes a reference to the --pageobject-driver option, which is no longer supported.